### PR TITLE
Fixes foreground color not getting set

### DIFF
--- a/configs/tatami/bin/xcolors
+++ b/configs/tatami/bin/xcolors
@@ -3,7 +3,7 @@
     return 1
 }
 
-xcolors="$(xrdb -query | egrep '(^\*color|^\*background|^*foreground)')"
+xcolors="$(xrdb -query | egrep '(^\*color|^\*background|^\*foreground)')"
 
 export bg="$(printf %s "$xcolors" | grep '^\*background' | cut -f2)"
 export fg="$(printf %s "$xcolors" | grep '^\*foreground' | cut -f2)"


### PR DESCRIPTION
Missing an escape on the '*' in the regex, causes the text in on the bar to be white and very hard to read